### PR TITLE
Add charts for Olive McBride

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -110,6 +110,17 @@
               </div>
             </div>
           </div>
+          <!-- Probability of passing with Olive McBride -->
+          <div class="card chart">
+            <header class="card-header">
+              <p class="card-header-title">Probability of Success with Olive McBride (counts only token modifiers before resolution)</p>
+            </header>
+            <div class="card-content">
+              <div class="content">
+                <highcharts :options="successChartOptionsWithOlive" class="vh70"></highcharts>
+              </div>
+            </div>
+          </div>
           <!-- Probability of Token Card -->
           <div class="card chart">
             <header class="card-header">
@@ -192,6 +203,7 @@ import bags from "./lookups/bags";
 import cards from "./lookups/cards";
 // functions
 import applyToken from "./functions/applyToken";
+import calculateTokenModifier from "./functions/calculateTokenModifier";
 import probabilityOfToken from "./functions/probabilityOfToken";
 
 export default {
@@ -324,6 +336,61 @@ export default {
         series: [{ data: this.probabilitiesOfSuccess(), color: "#00d1b2" }]
       };
     },
+    successChartOptionsWithOlive() {
+      return {
+        chartType: "line",
+        // chart: {
+        //   backgroundColor: "#363636"
+        // },
+        chart: {
+          height: 300
+        },
+        credits: {
+          enabled: false
+        },
+        title: {
+          text: ""
+        },
+        legend: {
+          enabled: false
+        },
+        yAxis: {
+          title: {
+            text: "Probability of success (percent)"
+            // style: {
+            //   color: "white"
+            // }
+          },
+          max: 100,
+          min: 0
+        },
+        xAxis: {
+          title: {
+            text: "Difference betweeen test difficulty and character skill"
+            // style: {
+            //   color: "white"
+            // }
+          },
+          type: "category",
+          categories: this.tests
+        },
+        plotOptions: {
+          line: {
+            dataLabels: {
+              enabled: true,
+              formatter: function() {
+                return this.x + ": " + this.y + "%";
+              }
+              // style: {
+              //   color: "white",
+              //   textOutline: "0px"
+              // }
+            }
+          }
+        },
+        series: [{ data: this.probabilitiesOfSuccessWithOlive(), color: "#00d1b2" }]
+      };
+    },
     bag() {
       let bag = [];
       Object.values(this.tokens).forEach(token => {
@@ -374,6 +441,55 @@ export default {
           this.characterIdx
         );
         probabilities.push(probability);
+      });
+      return probabilities;
+    },
+    probabilitiesOfSuccessWithOlive(bag = this.bag) {
+      let probabilities = [];
+      let bagModifiers = [];
+      for (let i = 0; i < bag.length; i++) {
+        let a;
+        if (bag[i].label !== 'Autofail') {
+          a = calculateTokenModifier(bag[i], bag, this.cards, this.characterIdx);
+        } else {
+          a = -100;
+        }
+        bagModifiers.push(a);
+      }
+
+      this.tests.forEach(test => {
+        let results = [];
+        let triads = [];
+        let indexes = [];
+        for (let i = 0; i < bag.length; i++) {
+          up:
+            for (let j = 0; j < bag.length; j++) {
+              for (let k = 0; k < bag.length; k++) {
+                if(i === j || i === k || j === k) {
+                  continue up;
+                }
+                let temp = [i, j, k].sort(function(a,b){return a - b}).join();
+                if (!indexes.includes(temp)) {
+                  indexes.push(temp);
+                  temp = [bagModifiers[i], bagModifiers[j], bagModifiers[k]].sort(function(a,b){return a - b});
+                  triads.push(temp);
+                }
+              }
+            }
+        }
+        triads.forEach(triad => {
+          let success = triad[1] + triad[2] + test >= 0;
+          if (!success && test == 6 && triad.includes(-5)) {
+            window.console.log(triad);
+          }
+          results.push(success * 1);
+        });
+
+        let sum = results.reduce((a, b) => a + b, 0);
+
+        let outcome = Math.round((sum / results.length) * 100);
+
+        probabilities.push(outcome);
       });
       return probabilities;
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -111,7 +111,7 @@
             </div>
           </div>
           <!-- Probability of passing with Olive McBride -->
-          <div class="card chart">
+          <div class="card chart" :class="{ 'hidden': !cards['Olive McBride'] }">
             <header class="card-header">
               <p class="card-header-title">Probability of Success with Olive McBride (counts only token modifiers before resolution)</p>
             </header>
@@ -129,6 +129,17 @@
             <div class="card-content">
               <div class="content">
                 <highcharts :options="tokenChartOptions" class="vh70"></highcharts>
+              </div>
+            </div>
+          </div>
+          <!-- Probability of Token Revealing with Olive McBride -->
+          <div class="card chart" :class="{ 'hidden': !cards['Olive McBride'] }">
+            <header class="card-header">
+              <p class="card-header-title">Probability of Token Revealing with Olive McBride</p>
+            </header>
+            <div class="card-content">
+              <div class="content">
+                <highcharts :options="tokenChartOptionsWithOlive" class="vh70"></highcharts>
               </div>
             </div>
           </div>
@@ -205,6 +216,7 @@ import cards from "./lookups/cards";
 import applyToken from "./functions/applyToken";
 import calculateTokenModifier from "./functions/calculateTokenModifier";
 import probabilityOfToken from "./functions/probabilityOfToken";
+import probabilityOfTokenReveal from "./functions/probabilityOfTokenReveal";
 
 export default {
   name: "app",
@@ -261,6 +273,59 @@ export default {
         series: [
           {
             data: this.probabilitiesOfToken(),
+            color: "#00d1b2",
+            type: "column"
+          }
+        ],
+        plotOptions: {
+          column: {
+            dataLabels: {
+              enabled: true,
+              formatter: function() {
+                return String(parseFloat(this.y).toFixed(2)) + "%";
+              }
+              // style: {
+              //   color: "white",
+              //   textOutline: "0px"
+              // }
+            }
+          }
+        }
+      };
+    },
+    tokenChartOptionsWithOlive() {
+      return {
+        chart: {
+          height: 300
+        },
+        chartType: "column",
+        legend: {
+          enabled: false
+        },
+        credits: {
+          enabled: false
+        },
+        title: {
+          text: ""
+        },
+        xAxis: {
+          categories: this.tokens.map(token => token.label),
+          title: {
+            text: "Tokens"
+          },
+          type: "category"
+        },
+        yAxis: {
+          title: {
+            text: "Probability of Revealing (percent)"
+          },
+          max: 80,
+          min: 0,
+          type: "column"
+        },
+        series: [
+          {
+            data: this.probabilitiesOfTokenWithOlive(),
             color: "#00d1b2",
             type: "column"
           }
@@ -444,6 +509,18 @@ export default {
       });
       return probabilities;
     },
+    probabilitiesOfTokenWithOlive() {
+      let probabilities = [];
+      this.tokens.forEach(token => {
+        let probability = probabilityOfTokenReveal(
+          token,
+          this.bag,
+          this.characterIdx
+        );
+        probabilities.push(probability);
+      });
+      return probabilities;
+    },
     probabilitiesOfSuccessWithOlive(bag = this.bag) {
       let probabilities = [];
       let bagModifiers = [];
@@ -479,9 +556,6 @@ export default {
         }
         triads.forEach(triad => {
           let success = triad[1] + triad[2] + test >= 0;
-          if (!success && test == 6 && triad.includes(-5)) {
-            window.console.log(triad);
-          }
           results.push(success * 1);
         });
 

--- a/src/functions/applyToken.js
+++ b/src/functions/applyToken.js
@@ -1,23 +1,6 @@
 import characters from '../lookups/characters'
 export default function applyToken(test, token, bag, cards, characterIdx, results) {
-  let multiDrawCards = [
-    "Dark Prophecy",
-    "Dark Prophecy (second copy)",
-    "Grotesque Statue",
-    "Grotesque Statue (second copy)",
-    "Olive McBride"
-  ]
-  let multiDrawCondition = false
-  multiDrawCards.forEach(card => {
-    if (cards[card]) {
-      multiDrawCondition = true
-    }
-  })
-  if (multiDrawCondition) {
-    return
-  } else {
-    return applyTokenNormally(test, token, bag, cards, characterIdx, results)
-  }
+  return applyTokenNormally(test, token, bag, cards, characterIdx, results)
 }
 
 function applyTokenNormally(test, token, bag, cards, characterIdx, results) {

--- a/src/functions/calculateTokenModifier.js
+++ b/src/functions/calculateTokenModifier.js
@@ -1,0 +1,56 @@
+import characters from '../lookups/characters'
+export default function calculateTokenModifier(token, bag, cards, characterIdx) {
+  return calculateModifier(token, bag, cards, characterIdx)
+}
+
+function calculateModifier(token, bag, cards, characterIdx) {
+  let character = characterIdx ? characters[characterIdx] : {}
+  /******************************************
+   * set up card-specific conditions        *
+   *******************************************/
+  // jim culver
+  let jimCulver = character.name === "Jim Culver" && token.label == "Skull"
+
+  /******************************************
+   * apply modifiers                         *
+   *******************************************/
+  let test = 0
+
+  if (token.symbol && cards["Counterspell"]) {
+    return test
+  }
+
+  // recall the future(s)
+  if (
+    token.label === cards["Recall the Future"] &&
+    !token.appliedModifiers.includes("Recall the Future")
+  ) {
+    test += 2
+    token.appliedModifiers.push("Recall the Future")
+  }
+  if (
+    token.label === cards["Recall the Future (second copy)"] &&
+    !token.appliedModifiers.includes("Recall the Future (second copy)")
+  ) {
+    test += 2
+    token.appliedModifiers.push("Recall the Future (second copy)")
+  }
+
+  // apply card effects
+  if (cards["Ritual Candles"] && token.symbol) {
+    test += 1
+  }
+  if (cards["Ritual Candles (second copy)"] && token.symbol) {
+    test += 1
+  }
+
+  /******************************************
+   * apply token effect                      *
+   *******************************************/
+  // if the token isn't being nulled by jim or defiance
+  if (!(token.label === cards["Defiance"]) && !jimCulver) {
+    test += Number(token.effect)
+  }
+
+  return Number(test)
+}

--- a/src/functions/probabilityOfTokenReveal.js
+++ b/src/functions/probabilityOfTokenReveal.js
@@ -1,0 +1,26 @@
+import characters from '../lookups/characters'
+export default function probabilityOfTokenReveal(token, bag, characterIdx) {
+    let bagSize = bag.length;
+    let tokenAmountInBag = tokenAmount(token, bag, characterIdx);
+    let first = (bagSize - tokenAmountInBag) / bagSize;
+    let second = (bagSize - tokenAmountInBag - 1) / (bagSize - 1);
+    let third = (bagSize - tokenAmountInBag - 2) / (bagSize - 2);
+    let probability = 1 - (first * second * third);
+    return probability * 100
+}
+
+function tokenAmount(token, bag, characterIdx) {
+    let character = characterIdx ? characters[characterIdx] : {}
+    let jimCulver = (character.name === "Jim Culver" && token.label === "Skull")
+
+    let results = []
+    bag.forEach(bagToken => {
+        if (bagToken.label === token.label || (bagToken.label === "Elder Sign" && jimCulver)) {
+            results.push(1)
+        } else {
+            results.push(0)
+        }
+    })
+
+    return results.reduce((a, b) => a + b, 0)
+}

--- a/src/lookups/cards.js
+++ b/src/lookups/cards.js
@@ -7,7 +7,7 @@ export default {
     Defiance: false,
     // "Dark Prophecy": false,
     // "Dark Prophecy (second copy)": false,
-    // "Olive McBride": false,
+    "Olive McBride": false,
     // "Grotesque Statue": false,
     // "Grotesque Statue (second copy)": false,
     // "Rex's Curse": false,


### PR DESCRIPTION
Hello!

I've added Olive McBride support to arkham-bag-calculator. I've enabled her in cards and created a couple of charts which appear if Olive is checked.
![image](https://user-images.githubusercontent.com/3006537/105629672-85813280-5e55-11eb-8b48-e367138cbe3e.png)
![image](https://user-images.githubusercontent.com/3006537/105629678-8dd96d80-5e55-11eb-8c1b-c7e84bf4e0f4.png)
![image](https://user-images.githubusercontent.com/3006537/105629684-9631a880-5e55-11eb-8dc3-9c8433946926.png)

Please, forgive me for writing non-perfect JS code, I'm a PHP developer and have only basic knowledge of JS and Vue.js. I understand that I copied a lot of code which violates DRY principle, but this enables a much needed (at least for me haha) feature, and we can refactor it later.

I used hidden class instead of v-if because highcharts went nuts with v-if.
